### PR TITLE
Fixup disabled text

### DIFF
--- a/canvasvg.py
+++ b/canvasvg.py
@@ -144,8 +144,17 @@ def convert(document, canvas, items=None, tounicode=None):
 		if state == ACTIVE:
 			width = max(float(options['activewidth']), width)
 		elif state == DISABLED:
-			if float(options['disabledwidth']) > 0:
-				width = options['disabledwidth']
+			try:
+				disabledwidth = options['disabledwidth']
+			except KeyError:
+				# Text item might not have 'disabledwidth' option. This raises
+				# the exception in course of processing of such item.
+				# Default value is 0. Hence, it shall not affect width.
+				pass
+			else:
+				if float(disabledwidth) > 0:
+					width = disabledwidth
+
 	
 		if width != 1.0:
 			style['stroke-width'] = width

--- a/test/test-text-diabled.py
+++ b/test/test-text-diabled.py
@@ -1,0 +1,11 @@
+from framework import *
+root.title("Disabled text")
+
+canv.create_text(200, 200,
+	text = "Test disabled text",
+	font = ("Times", 20),
+	state = DISABLED
+)
+
+thread.start_new_thread(test, (canv, __file__, True))
+root.mainloop()


### PR DESCRIPTION
Conversion process fails if there is a disabled text item without explicitly set 'disabledwidth' option.

The patch series adds the test that reproduces the issue. Then it suggests the solution.