### PR TITLE
Configurable tags for segments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,18 @@ method ``canvassvg.warnings(mode)`` with three possible values:
 * ``canvassvg.NONE``   --- do not print any message.
 
 
+``configure(*flags)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Module might use either ``<path>`` or ``<line>`` tag for segment
+representation. By default it uses ``<line>``. The behaviour could be changed
+globally by calling ``canvassvg.configure(*flags)`` with one of consequent
+values:
+
+* ``canvassvg.SEGMENT_TO_LINE`` --- use ``<line>`` tag;
+* ``canvassvg.SEGMENT_TO_PATH`` --- use ``<path>`` tag.
+
+
 Changelog
 ------------------------------------------------------------------------
 

--- a/canvasvg.py
+++ b/canvasvg.py
@@ -80,6 +80,7 @@ def convert(document, canvas, items=None, tounicode=None):
 	Return list of XML elements
 	"""
 	tk = canvas.tk
+	global segment
 
 	if items is None:	# default: all items
 		items = canvas.find_all()
@@ -208,7 +209,7 @@ def convert(document, canvas, items=None, tounicode=None):
 			elif options['smooth'] == '0':
 				if len(coords) == 4:
 					# segment
-					element = segment_to_line(document, coords)
+					element = segment(document, coords)
 				else:
 					# polyline
 					element = polyline(document, coords)

--- a/canvasvg.py
+++ b/canvasvg.py
@@ -192,7 +192,7 @@ def convert(document, canvas, items=None, tounicode=None):
 			elif options['smooth'] == '0':
 				if len(coords) == 4:
 					# segment
-					element = segment(document, coords)
+					element = segment_to_line(document, coords)
 				else:
 					# polyline
 					element = polyline(document, coords)
@@ -358,8 +358,8 @@ def saveall(filename, canvas, items=None, margin=10, tounicode=None):
 #========================================================================
 # canvas elements geometry
 
-def segment(document, coords):
-	"polyline with 2 vertices"
+def segment_to_line(document, coords):
+	"polyline with 2 vertices using <line> tag"
 	return setattribs(
 		document.createElement('line'),
 		x1 = coords[0],

--- a/canvasvg.py
+++ b/canvasvg.py
@@ -52,6 +52,22 @@ def emit_warning(msg):
 		stderr.write(msg)
 		stderr.write('\n')
 
+SEGMENT_TO_LINE = 1000
+SEGMENT_TO_PATH = 2000
+
+def configure(*flags):
+	global segment
+
+	for flag in flags:
+		if flag == SEGMENT_TO_LINE:
+			segment = segment_to_line
+		elif flag == SEGMENT_TO_PATH:
+			segment = segment_to_path
+		else:
+			raise ValueError(
+				"Please use one of constants: SEGMENT_TO_LINE, SEGMENT_TO_PATH"
+			)
+
 def convert(document, canvas, items=None, tounicode=None):
 	"""
 	Convert 'items' stored in 'canvas' to SVG 'document'.
@@ -374,6 +390,8 @@ def segment_to_path(document, coords):
 		document.createElement('path'),
 		d = "M%s,%s %s,%s" % tuple(coords[:4])
 	)
+
+segment = segment_to_line
 
 def polyline(document, coords):
 	"polyline with more then 2 vertices"

--- a/canvasvg.py
+++ b/canvasvg.py
@@ -368,6 +368,12 @@ def segment_to_line(document, coords):
 		y2 = coords[3],
 	)
 
+def segment_to_path(document, coords):
+	"polyline with 2 vertices using <path> tag"
+	return setattribs(
+		document.createElement('path'),
+		d = "M%s,%s %s,%s" % tuple(coords[:4])
+	)
 
 def polyline(document, coords):
 	"polyline with more then 2 vertices"

--- a/test/test-line-path.py
+++ b/test/test-line-path.py
@@ -1,0 +1,11 @@
+from framework import *
+root.title("Segments test ($Revision: 1.3 $)")
+
+n = 100
+for i in xrange(n):
+	item = canv.create_line(coord(), coord(), coord(), coord())
+	canv.itemconfigure(item, fill=random_color())
+
+canvasvg.configure(canvasvg.SEGMENT_TO_PATH)
+thread.start_new_thread(test, (canv, __file__, True))
+root.mainloop()


### PR DESCRIPTION
The issue addresses the Incscape 0.91 restriction.

canvas2svg uses line tag to generate segments. Incscape does not support editing points of segments represented by line tag. Only rotation and translation of entire segment are supported. There is a workaround. A line could be converted to a path manually, but it is quite annoying.

At the other hand, canvas2svg could be improved to provide selection of tag to be used for current conversion.

The canvas2svg is used to generate file which is expected to be edited with Incscape. So, it would be handy for user if path tag is used for segments.

This patch series adds such ability. Backward compatibility is preserved by using corresponding default parameter value.