### PR TITLE
canvasvg: add configure and SEGMENT_TO_LINE(PATH) names to module index

### DIFF
--- a/canvasvg.py
+++ b/canvasvg.py
@@ -11,7 +11,9 @@ from __future__ import division
 
 __author__  = "Wojciech Muła <wojciech_mula@poczta.onet.pl>"
 
-__all__ = ["convert", "SVGdocument", "saveall", "PYTHON", "MODULE", "NONE", "warnings"]
+__all__ = ["convert", "SVGdocument", "saveall", "PYTHON", "MODULE", "NONE",
+	"warnings", "configure", "SEGMENT_TO_LINE", "SEGMENT_TO_PATH"
+]
 
 try:
 	# python3


### PR DESCRIPTION
I had forgot to add `configure`, `SEGMENT_TO_LINE` and `SEGMENT_TO_PATH` to module index. If module is imported using `from canvasvg import *` instruction, it results in `NameError`.