### PR TITLE
Support empty canvas

### DIFF
--- a/canvasvg.py
+++ b/canvasvg.py
@@ -338,7 +338,11 @@ def saveall(filename, canvas, items=None, margin=10, tounicode=None):
 		doc.documentElement.appendChild(element)
 
 	if items is None:
-		x1, y1, x2, y2 = canvas.bbox(ALL)
+		bbox = canvas.bbox(ALL)
+		if bbox is None:
+			x1, y1, x2, y2 = 0, 0, 0, 0
+		else:
+			x1, y1, x2, y2 = bbox
 	else:
 		x1 = None
 		y1 = None

--- a/test/test-empty.py
+++ b/test/test-empty.py
@@ -1,0 +1,8 @@
+from framework import *
+
+# This test reproduces `TypeError: 'NoneType' object is not iterable` raised on
+# empty canvas conversion attempt.
+
+canvasvg.saveall(__file__ + '.svg', canv)
+
+os.system("inkview %s.svg" % __file__)


### PR DESCRIPTION
There is a problem in `saveall` function. It uses `Canvas.bbox` to obtain the image
size. Given an empty canvas, `bbox(ALL)` returns `None`. Attempt to unpack
`None` as  a tuple onto `x1, y1, x2, y2` raises `TypeError`.

This patch series adds the test that reproduces this error, then it applies the fix.