### PR TITLE
Support angle for text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 *.pyc
 *.svg
+.DS_Store
 dist
 MANIFEST

--- a/canvasvg.py
+++ b/canvasvg.py
@@ -263,15 +263,15 @@ def convert(document, canvas, items=None, tounicode=None):
 
 		elif itemtype == 'text':
 			style['stroke'] = '' # no stroke
-			
+
 			# setup geometry
 			xmin, ymin, xmax, ymax = canvas.bbox(item)
-			
+
 			x = coords[0]
 
 			# set y at 'dominant-baseline'
 			y = ymin + font_metrics(tk, options['font'], 'ascent') 
-			
+
 			element = setattribs(
 				document.createElement('text'),
 				x = x, y = y 
@@ -288,6 +288,22 @@ def convert(document, canvas, items=None, tounicode=None):
 			style['fill'] = HTMLcolor(canvas, get('fill'))
 			style["text-anchor"] = text_anchor[options["anchor"]]
 			style['font-family'] = actual['family']
+
+			# starting from tkinter version 8.6 text can have an angle
+			if 'angle' in options and tkinter.TkVersion >= 8.6:
+				angle = float(options['angle'])
+				if angle != 0:
+					# rotate to 0° to get correct bbox
+					canvas.itemconfigure(item, angle=0)
+					xmin, ymin, xmax, ymax = canvas.bbox(item)
+					# rotate back
+					canvas.itemconfigure(item, angle=angle)
+
+					# update y at the correct rotated position and keep
+					# y at 'dominant-baseline'
+					y = ymin + font_metrics(tk, options['font'], 'ascent')
+					element.setAttribute("y", str(y))
+					style['transform'] = "rotate(%s, %s, %s)" % (-angle, x, coords[1])
 
 			# size
 			size = float(actual['size'])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def get_readme():
 
 setup(
     name                = 'canvasvg',
-    version             = '1.0.5',
+    version             = '1.0.6',
     description         = "Save Tkinter Canvas in SVG file",
     author              = "Wojciech Muła",
     author_email        = "wojciech_mula@poczta.onet.pl",

--- a/test/test-text-angle.py
+++ b/test/test-text-angle.py
@@ -1,0 +1,25 @@
+from framework import *
+
+root.title("Rotated text")
+
+for rot in range(0, 360, 45):
+	canv.create_text(100, 200,
+		text	= "Rotated %s deg" % rot,
+		angle	= rot,
+		fill	= random_color(),
+		font	= ("Helvetica", 8),
+		anchor	= W,
+	)
+
+
+for rot in range(0, 360, 45):
+	canv.create_text(300, 200,
+		text	= "Rotated %s deg" % rot,
+		angle	= rot,
+		fill	= random_color(),
+		font	= ("Helvetica", 8),
+		anchor	= E,
+	)
+
+thread.start_new_thread(test, (canv, __file__, True))
+root.mainloop()


### PR DESCRIPTION
tkinter 8.6 introduced a new property `angle` to rotate text. This is currently not supported by canvas2svg. This PR adds the capability to rotate text through svgs `transform` property. An example was added to the test-folder `test-text-angle.py`.